### PR TITLE
Fix MacOS aws-sdk-cpp Dependency Failing Build

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -37,7 +37,6 @@ jobs:
         path: cppcheck-results.log
     - name: get-dependencies
       run: |
-        brew unlink unixodbc
         brew install curl
         brew install cmake
         brew install libiodbc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,7 +120,7 @@ elseif(APPLE)
 								SQLCOLATTRIBUTE_SQLLEN
 							)
 	# iODBC includes
-	include_directories(/usr/local/include)
+	include_directories(/usr/local/opt/libiodbc/include)
 elseif(UNIX)
 	# Unix specific
 	add_compile_definitions	(	WITH_UNIXODBC	

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -1,12 +1,12 @@
 {
     "name": "sql-odbc",
     "version-string": "1.1.0.1",
-    "dependencies": ["aws-sdk-cpp", "rapidjson", "zlib", "gtest", "curl"],
-    "builtin-baseline": "6ca56aeb457f033d344a7106cb3f9f1abf8f4e98",
-    "overrides": [
-        { "name": "aws-sdk-cpp", "version": "1.8.83#2" },
-        { "name": "rapidjson", "version": "2022-06-28#1" },
-        { "name": "zlib", "version": "1.2.12#1" },
-        { "name": "gtest", "version": "1.11.0" }
-    ]
+    "dependencies": [
+        "aws-sdk-cpp",
+        "rapidjson",
+        "zlib",
+        "gtest",
+        "curl"
+    ],
+    "builtin-baseline": "a325228200d7f229f3337e612e0077f2a5307090"
 }


### PR DESCRIPTION
### Description
Fix failing MacOS build.
 
### Issues Resolved
[#37](https://github.com/opensearch-project/sql-odbc/issues/37)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).